### PR TITLE
Updates `ch1-time-api` to run with rust 1.44.1 and rocket 0.4.5

### DIFF
--- a/ch1/ch1-time-api/Cargo.toml
+++ b/ch1/ch1-time-api/Cargo.toml
@@ -5,12 +5,11 @@ authors = ["Tim McNamara <code@timmcnamara.co.nz>"]
 
 [dependencies]
 chrono = "0.4.0"
-rocket = "0.3.0"
-rocket_codegen = "0.3.0"
+rocket = "0.4.5"
 serde = "1.0"
 serde_derive = "1.0"
 
 [dependencies.rocket_contrib]
-version = "0.3.0"
+version = "0.4.5"
 default-features = false
 features = ["json"]

--- a/ch1/ch1-time-api/src/main.rs
+++ b/ch1/ch1-time-api/src/main.rs
@@ -1,16 +1,17 @@
-#![feature(plugin)] // <1>
-#![plugin(rocket_codegen)] // <1>
+#![feature(proc_macro_hygiene, decl_macro)]
+
+#[macro_use]
+extern crate rocket;
 
 extern crate serde;          // <2>
 extern crate chrono;         // <2>
-extern crate rocket;         // <2>
 extern crate rocket_contrib; // <2>
 
 #[macro_use]  // <3> Syntax to indicate that we want to import macros from another module
 extern crate serde_derive;   // <3>
 
 use chrono::prelude::*; // <4> brings all exported members into local scope (e.g. DateTime and Utc)
-use rocket_contrib::{Json}; // <5> bring single member into local scope
+use rocket_contrib::json::{Json}; // <5> bring single member into local scope
 
 #[derive(Serialize)] // <6> Automatically generate a string representation of this struct (which will be used as JSON)
 struct Timestamp { // <7> Syntax to create a custom type 


### PR DESCRIPTION
This is what I had to do to get `ch1-time-api` to run on latest rust, cargo, and rocket.

Below is my `rustc` and `cargo` version along with the output I get from `cargo +nightly run` on current master.

```
$ rustc --version
rustc 1.44.1 (c7087fe00 2020-06-17)

$ cargo --version
cargo 1.44.1 (88ba85757 2020-06-11)

$ cargo +nightly run
    Updating crates.io index
error: failed to select a version for the requirement `ring = "^0.11.0"`
  candidate versions found which didn't match: 0.16.15, 0.16.14, 0.16.13, ...
  location searched: crates.io index
required by package `cookie v0.9.1`
    ... which is depended on by `rocket v0.3.0`
    ... which is depended on by `ch1-time-api v0.1.0 (/home/mike/workspace/rust-in-action/code/ch1/ch1-time-api)`
```