### PR TITLE
WIP - ActionKV Index Maintenance - maybe bug

### DIFF
--- a/ch7/ch7-actionkv2/Cargo.toml
+++ b/ch7/ch7-actionkv2/Cargo.toml
@@ -2,6 +2,7 @@
 name = "actionkv"
 version = "0.1.0"
 authors = ["Tim McNamara <code@timmcnamara.co.nz>"]
+edition = "2018"
 
 [dependencies]
 crc = "1.7"
@@ -9,6 +10,9 @@ byteorder = "1.2"
 serde = "1"
 serde_derive = "1"
 bincode = "*"
+
+[dev-dependencies]
+tempdir = "0.3"
 
 [lib]
 name = "libactionkv"

--- a/ch7/ch7-actionkv2/src/lib.rs
+++ b/ch7/ch7-actionkv2/src/lib.rs
@@ -248,7 +248,7 @@ mod tests {
 
         store.insert(key4, val4).expect("failed to insert key4");
 
-        let retrieved_key_4 = store.get(key4).expect("failed to retrieve key 3");
+        let retrieved_key_4 = store.get(key4).expect("failed to retrieve key 4");
         let retrieved_val_4 = retrieved_key_4.expect("None returned for key1");
         println!("index: {:?}", store.index);
         assert_eq!(val4, retrieved_val_4.as_slice());

--- a/ch7/ch7-actionkv2/src/lib.rs
+++ b/ch7/ch7-actionkv2/src/lib.rs
@@ -112,14 +112,6 @@ impl ActionKV {
         f.seek(SeekFrom::Start(position))?;
         let kv = ActionKV::process_record(&mut f)?;
 
-        // Even though `f.seek` does take `&mut self`, my understanding is calling it
-        // with `SeekFrom::Current(0)` simply says "where am I at in the stream" without
-        // altering anything. In fact there's even a convenience function that claims
-        // exactly this: https://doc.rust-lang.org/std/io/trait.Seek.html#method.stream_position
-        //
-        // However, commenting these two lines makes `test_index_maintenance` pass
-        let final_pos = f.seek(SeekFrom::Current(0))?;
-        println!("after reading at {}, final_pos is {}", position, final_pos);
         Ok(kv)
     }
 
@@ -179,15 +171,12 @@ impl ActionKV {
 
         let checksum = crc32::checksum_ieee(&tmp);
 
-        let next_byte = SeekFrom::End(0);
-        let current_position = f.seek(SeekFrom::Current(0))?;
-        f.seek(next_byte)?;
+        let current_position = f.seek(SeekFrom::End(0))?;
         f.write_u32::<LittleEndian>(checksum)?;
         f.write_u32::<LittleEndian>(key_len as u32)?;
         f.write_u32::<LittleEndian>(val_len as u32)?;
         f.write_all(&mut tmp)?;
 
-        println!("current_position: {}, {:?}, {:?}", current_position, key, value);
         Ok(current_position)
     }
 
@@ -232,16 +221,6 @@ mod tests {
         store.insert(key1, val1).expect("failed to insert key1");
         store.insert(key2, val2).expect("failed to insert key2");
         store.insert(key3, val3).expect("failed to insert key3");
-
-        // My understanding of how everything works is that retreiving `key1` *should* leave the file
-        // pointing at the start of `key2`.
-        //
-        // Thus when we insert `4`, even though it gets *written* to the end of the file, the
-        // index will be pointing to the incorrect location.
-        //
-        // You can verify this by inspecting the `index` values that get printed or retrieving the incorrect value for `key4`
-        //
-        // However, that only happens **WITH** the .seek(Current(0))` in `get_at`
 
         let retrieved_key_1 = store.get(key1).expect("failed to retrieve key 1");
         let retrieved_val_1 = retrieved_key_1.expect("None returned for key1");

--- a/ch7/ch7-actionkv2/src/lib.rs
+++ b/ch7/ch7-actionkv2/src/lib.rs
@@ -208,6 +208,7 @@ impl ActionKV {
 mod tests {
     use super::ActionKV;
     use tempdir::TempDir;
+    use std::collections::HashSet;
 
     #[test]
     fn test_index_maintenance() {
@@ -250,7 +251,14 @@ mod tests {
 
         let retrieved_key_4 = store.get(key4).expect("failed to retrieve key 4");
         let retrieved_val_4 = retrieved_key_4.expect("None returned for key1");
-        println!("index: {:?}", store.index);
+        let unique_positions = {
+            let mut tmp = HashSet::new();
+            for position in store.index.values() {
+                tmp.insert(position);
+            }
+            tmp.len()
+        };
+        assert_eq!(store.index.values().count(), unique_positions);
         assert_eq!(val4, retrieved_val_4.as_slice());
     }
 }

--- a/ch7/ch7-actionkv2/src/lib.rs
+++ b/ch7/ch7-actionkv2/src/lib.rs
@@ -232,6 +232,16 @@ mod tests {
         store.insert(key2, val2).expect("failed to insert key2");
         store.insert(key3, val3).expect("failed to insert key3");
 
+        // My understanding of how everything works is that retreiving `key1` *should* leave the file
+        // pointing at the start of `key2`.
+        //
+        // Thus when we insert `4`, even though it gets *written* to the end of the file, the
+        // index will be pointing to the incorrect location.
+        //
+        // You can verify this by inspecting the `index` values that get printed or retrieving the incorrect value for `key4`
+        //
+        // However, that only happens **WITH** the .seek(Current(0))` in `get_at`
+
         let retrieved_key_1 = store.get(key1).expect("failed to retrieve key 1");
         let retrieved_val_1 = retrieved_key_1.expect("None returned for key1");
         assert_eq!(val1, retrieved_val_1.as_slice());


### PR DESCRIPTION
Hey - want to start out by saying thank again for the great book!

The `insert_but_ignore_index` code appears incorrect to me. If the underlying file is pointing at position `in_the_middle` when `insert` is called, the KV will be correctly appended at the end of the file, but the `index` will say the KV is at position `in_the_middle`

https://github.com/rust-in-action/code/blob/e23c70ec1cb9e9b9037f364b8edfa6ee882e8f77/ch7/ch7-actionkv2/src/lib.rs#L174-L182

I wrote `test_index_maintenance` to confirm my suspicion, expecting it to fail. But the test passes!

To understand what was happening, I altered `get_at` to print out the file' position after performing the read - and then the test fails!

```rust
    pub fn get_at(&mut self, position: u64) -> io::Result<KeyValuePair> {
        let mut f = BufReader::new(&mut self.f);
        f.seek(SeekFrom::Start(position))?;
        let kv = ActionKV::process_record(&mut f)?;

        // Even though `f.seek` does take `&mut self`, my understanding is calling it
        // with `SeekFrom::Current(0)` simply says "where am I at in the stream" without
        // altering anything. In fact there's even a convenience function that claims
        // exactly this: https://doc.rust-lang.org/std/io/trait.Seek.html#method.stream_position
        //
        // However, commenting these two lines makes `test_index_maintenance` pass
        let final_pos = f.seek(SeekFrom::Current(0))?;
        println!("after reading at {}, final_pos is {}", position, final_pos);
        Ok(kv)
    }
```

So now there's at least these few options on what's going on.

1) `.seek(SeekFrom::Current(0))` is not actually a functional no-op, and calling it breaks the system in some expected way. i.e. what I thought looked like a bug in `.insert` isn't a bug.
2) There is a bug in `.insert` and for some *magic* the `.seek(SeekFrom::Current(0))` sheds light on it. (Maybe something due to the extra buffer flush?
3) `.seek(SeekFrom::Current(0))` is *intended* to be a no-op, but there is a bug in it that this case triggered.

I'd assume `1` is by far the most likely, followed by `2` and then `3` a long way off.

Either way hope this helps and interested to hear what the answer is!

(Related: #4 since it also mentions the in memory index)