### PR TITLE
Fix compilation and parameters for mandelbrot example

### DIFF
--- a/ch2/ch2-mandelbrot/src/main.rs
+++ b/ch2/ch2-mandelbrot/src/main.rs
@@ -17,15 +17,15 @@ fn calculate_mandelbrot(      // <2>
     let mut row: Vec<usize> = Vec::with_capacity(height);
     for img_x in 0..width {
 
-      let x_percent = (img_x as f64 / width as f64);
-      let y_percent = (img_y as f64 / height as f64);
+      let x_percent = img_x as f64 / width as f64;
+      let y_percent = img_y as f64 / height as f64;
       let cx = x_min + (x_max - x_min) * x_percent; // <8>
       let cy = y_min + (y_max - y_min) * y_percent; // <8>
       let escaped_at = mandelbrot_at_point(cx, cy, max_iters);
       row.push(escaped_at);
     }
 
-    all_rows.push(row);
+    rows.push(row);
   }
   rows
 }
@@ -53,13 +53,13 @@ fn render_mandelbrot(escape_vals: Vec<Vec<usize>>) {
     for column in row {
       let val = match column {
         0..=2 => ' ',
-        2..=5 => '.',
-        5..=10 => '•',
+        3..=5 => '.',
+        6..=10 => '•',
         11..=30 => '*',
-        30..=100 => '+',
-        100..=200 => 'x',
-        200..=400 => '$',
-        400..=700 => '#',
+        31..=100 => '+',
+        101..=200 => 'x',
+        201..=400 => '$',
+        401..=700 => '#',
         _ => '%',
       };
 
@@ -70,7 +70,7 @@ fn render_mandelbrot(escape_vals: Vec<Vec<usize>>) {
 }
 
 fn main() {
-  let mandelbrot = calculate_mandelbrot(1000, 2.0, 1.0, -1.0,
+  let mandelbrot = calculate_mandelbrot(1000, -2.0, 1.0, -1.0,
                                         1.0, 100, 24);
 
   render_mandelbrot(mandelbrot);


### PR DESCRIPTION
I was playing around with the example and saw that it doesn't compile and uses the wrong argument for `x_min`. I also fixed some overlapping range issues in the match clause of the render function.

fixes #28
fixes #29 