### PR TITLE
fix: update index on disk after deleting in ActionKV2

### DIFF
--- a/ch7/ch7-actionkv2/src/akv_disk.rs
+++ b/ch7/ch7-actionkv2/src/akv_disk.rs
@@ -62,7 +62,10 @@ fn main() {
       }
     }
 
-    "delete" => a.delete(key).unwrap(),
+    "delete" => {
+      a.delete(key).unwrap();
+      store_index_on_disk(&mut a, INDEX_KEY);       <2>
+    }
 
     "insert" => {
       let value = maybe_value.expect(&USAGE).as_ref();


### PR DESCRIPTION
The index on the disk isn't updated after deleting a key, which leads to it having no effect.

```
target/release/akv-disk dsk insert test 123                                                                                                                                                                                         
target/release/akv-disk dsk get test
[49, 50, 51]
target/release/akv-disk dsk delete test
target/release/akv-disk dsk get test
[49, 50, 51]
```