### PR TITLE
add comments, Listing 5.6 Inspecting endianness

### DIFF
--- a/ch5/ch5-endianness.rs
+++ b/ch5/ch5-endianness.rs
@@ -4,8 +4,8 @@ fn main() {
   let big_endian: [u8; 4]    = [0xAA, 0xBB, 0xCC, 0xDD];
   let little_endian: [u8; 4] = [0xDD, 0xCC, 0xBB, 0xAA];
 
-  let a: i32 = unsafe { transmute(big_endian)    }; <1>
-  let b: i32 = unsafe { transmute(little_endian) }; <1>
+  let a: i32 = unsafe { transmute(big_endian)    };  // <1>
+  let b: i32 = unsafe { transmute(little_endian) };  // <1>
 
   println!("{} vs {}", a, b);
 }

--- a/ch5/ch5-impossible-add.rs
+++ b/ch5/ch5-impossible-add.rs
@@ -1,7 +1,7 @@
-#[allow(arithmetic_overflow)]    <1>
+#[allow(arithmetic_overflow)]    // <1>
 
 fn main() {
   let (a, b) = (200, 200);
-  let c: u8 = a + b;             <2>
+  let c: u8 = a + b;             // <2>
   println!("200 + 200 = {}", c);
 }

--- a/ch6/ch6-pointer-intro.rs
+++ b/ch6/ch6-pointer-intro.rs
@@ -3,8 +3,8 @@ static C: [u8; 11] = [116, 104, 97, 110, 107, 115, 102, 105, 115, 104, 0];
 
 fn main() {
     let a = 42;
-    let b = &B;    <1>
-    let c = &C;    <1>
+    let b = &B;    // <1>
+    let c = &C;    // <1>
 
-    println!("a: {}, b: {:p}, c: {:p}", a, b, c);  <2>
+    println!("a: {}, b: {:p}, c: {:p}", a, b, c);  // <2>
 }


### PR DESCRIPTION
Code snippet from "Listing 5.6 Inspecting endianness". 

These should either be comments or removed entirely----they don't exist in the publication "Rust In Action"

CC @timClicks 