### PR TITLE
Listing 5.4 example, fix variables

### DIFF
--- a/ch5/ch5-bit-patterns.rs
+++ b/ch5/ch5-bit-patterns.rs
@@ -8,5 +8,5 @@ fn main() {
   let sixtyfivethousand_535: u16 = 0b1111_1111_1111_1111;
 
   print!("{}, {}, {}, ..., ", zero, one, two);
-  println!("{}, {}, {}", sixty5_533, sixty5_534, sixty5_535);
+  println!("{}, {}, {}", sixtyfivethousand_533, sixtyfivethousand_534, sixtyfivethousand_535);
 }


### PR DESCRIPTION
This is the code snippet for "Listing 5.4 How u16 bit patterns translate to a fixed number of integers". 

Although this is what the book has, this code will not compile. The variables are renamed in `println!()`. 

This is something that should be revised in the 2nd edition I suspect. 

CC @timClicks 