### PR TITLE
ch8-mget: correct the format of dependencies  in Cargo.toml

### DIFF
--- a/ch8/ch8-mget/Cargo.toml
+++ b/ch8/ch8-mget/Cargo.toml
@@ -7,12 +7,6 @@ edition = "2018"
 [dependencies]
 clap = "2"
 rand = "0.7"
-smoltcp = {
-  version = "0.6",
-  features = ["proto-igmp", "proto-ipv4", "verbose", "log"]
-}
-trust-dns = {
-  version = "0.16",
-  default-features = false
-}
+smoltcp = { version = "0.6", features = ["proto-igmp", "proto-ipv4", "verbose", "log"] }
+trust-dns = { version = "0.16", default-features = false }
 url = "2"


### PR DESCRIPTION
The original format of `Cargo.toml` triggers a compilation error:
```shell
➜  ch8-mget  cargo build
error: failed to parse manifest at `/.../rust-in-action-src/ch8/ch8-mget/Cargo.toml`

Caused by:
  could not parse input as TOML

Caused by:
  expected a table key, found a newline at line 10 column 12
```
my toolchain version:
```shell
stable-x86_64-unknown-linux-gnu (default)
rustc 1.57.0 (f1edd0429 2021-11-29)
```
After correction, it works all right:)