### PR TITLE
Fix comments in extended CHIP-8 emulator

### DIFF
--- a/ch5/ch5-cpu4/src/main.rs
+++ b/ch5/ch5-cpu4/src/main.rs
@@ -53,18 +53,19 @@ impl CPU {
         self.registers[vx as usize] = kk; 
     }
 
-    /// (7xkk) Add sets the value `kk` into register `vx`
+    /// (7xkk) Add adds the value `kk` into register `vx`
     fn add(&mut self, vx: u8, kk: u8) {
         self.registers[vx as usize] += kk; 
     }
 
+    /// (3xkk / 5xy_) SE  **S**kip if **e**qual
     fn se(&mut self, vx: u8, kk: u8) {
         if vx == kk {
             self.position_in_memory += 2;
         }
     }
 
-    /// () SNE  **S**tore if **n**ot **e**qual 
+    /// (4xkk) SNE  **S**kip if **n**ot **e**qual
     fn sne(&mut self, vx: u8, kk: u8) {
         if vx != kk {
             self.position_in_memory += 2;


### PR DESCRIPTION
Confirmed correctness [here](http://www.cs.columbia.edu/~sedwards/classes/2016/4840-spring/designs/Chip8.pdf).

- `0x7xkk`: "adds", not "sets"
- S(N)E: "skip", not "store"