### PR TITLE
fix TOML in Cargo.toml

### DIFF
--- a/ch8/ch8-mget/Cargo.toml
+++ b/ch8/ch8-mget/Cargo.toml
@@ -7,12 +7,6 @@ edition = "2018"
 [dependencies]
 clap = "2"
 rand = "0.7"
-smoltcp = {
-  version = "0.6",
-  features = ["proto-igmp", "proto-ipv4", "verbose", "log"]
-}
-trust-dns = {
-  version = "0.16",
-  default-features = false
-}
+smoltcp = {version = "0.6",features = ["proto-igmp", "proto-ipv4", "verbose", "log"]}
+trust-dns = {version = "0.16",default-features = false}
 url = "2"


### PR DESCRIPTION
per https://toml.io/en/v1.0.0#inline-table, `No newlines are allowed between the curly braces unless they are valid within a value`.

Fixes #77.