### PR TITLE
ch6: particles: working Dockerfile to see graphical output

### DIFF
--- a/ch6/ch6-particles/Dockerfile
+++ b/ch6/ch6-particles/Dockerfile
@@ -1,7 +1,22 @@
-FROM rust:1.30
+# Build container with:
+#
+# docker build . --tag particles
+#
+# Run container with something like:
+#
+# XSOCK=/tmp/.X11-unix
+# XAUTH=/tmp/.docker.xauth
+# touch "${XAUTH}"
+# xauth nlist :0 | sed -e 's/^..../ffff/' | xauth -f "${XAUTH}" nmerge -
+# docker run -ti -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro -v "${XSOCK}:${XSOCK}" -v "${XAUTH}:${XAUTH}" -v /dev/dri/card0:/dev/dri/card0 -e "XAUTHORITY=${XAUTH}" -e DISPLAY -e HOME -e USER --user "$(id -u):$(id -g)" --rm particles
+#
+FROM rust:1.66
+
+RUN apt-get update
+RUN apt-get -y install libxcursor-dev libxrandr2 libxi6 libx11-xcb1 libgl1
 
 WORKDIR /opt/particles
 COPY . .
-RUN [[ -f Cargo.lock ]] && rm Cargo.lock || true
+RUN test -f Cargo.lock && rm Cargo.lock || true
 RUN cargo build
-CMD ["particles"]
+CMD ["/opt/particles/target/debug/ch6-particles"]


### PR DESCRIPTION
Update Dockerfile:

a. to Rust 1.66 (current stable release)
b. to fix Cargo.lock cleanup (`[[ ]]` is bash built in only, not available)
c. install necessary X11 dependencies to actually run
d. fix the CMD to refer to the actual built filename (and path)

And also provide examples of how to build and run it, so that, at least from an Ubuntu 20.04 LTS host, it is actually possible to see the graphical output.

X11 library dependencies determined interactively, from an Ubuntu 20.04 LTS host; may not be the optional set, particularly with newer host distros moving increasingly to Wayland only.