### PR TITLE
ch8: wraperror2: remove map_err() call

### DIFF
--- a/ch8/misc/wraperror2.rs
+++ b/ch8/misc/wraperror2.rs
@@ -29,8 +29,8 @@ impl From<net::AddrParseError> for UpstreamError {
 }
 
 fn main() -> Result<(), UpstreamError> {
-    let _f = File::open("invisible.txt").map_err(UpstreamError::IO)?;
-    let _localhost = "::1".parse::<Ipv6Addr>().map_err(UpstreamError::Parsing)?;
+    let _f = File::open("invisible.txt")?;
+    let _localhost = "::1".parse::<Ipv6Addr>()?;
 
     Ok(())
 }


### PR DESCRIPTION
To match the book text (Listing 8.15, which is supposed to match `ch8/misc/wraperror2.rs`), actually remove the `map_err()` calls that are not supposed to be needed once the `std::convert::From` trait is implemented for the wrapped types.

Without this change, the difference between `wraperror.rs` and `wraperror2.rs` is not particularly obvious, as the `std::convert::From` traits are unnecessary.   (The code does compile without this change, because the in repository implementation is basically the same as `ch8/misc/wraperror.rs`.)

**ETA**: Force pushed a replacement to fix typo in commit comment that I noticed while editing the PR text.