### PR TITLE
ch8/ch8-mac: Clear Unicast/Multicast bit

### DIFF
--- a/ch8/ch8-mac/src/main.rs
+++ b/ch8/ch8-mac/src/main.rs
@@ -19,11 +19,19 @@ impl Display for MacAddress {
   }
 }
 
+// MAC address format summary:
+// https://en.wikipedia.org/wiki/MAC_address#Address_details
+//
+// 1st Octet:
+// -- bit 0 (LSB): 0 = unicast             / 1 = multicast
+// -- bit 1:       0 = globally unique OUI / 1 = locally assigned
+//
 impl MacAddress {
   fn new() -> MacAddress {
     let mut octets: [u8; 6] = [0; 6];
     rand::thread_rng().fill_bytes(&mut octets);
-    octets[0] |= 0b_0000_0011;                     // <3>
+    octets[0] |= 0b_0000_0010;                     // <3>
+    octets[0] &= 0b_1111_1110;                     // <3>
     MacAddress { 0: octets }
   }
 
@@ -32,7 +40,7 @@ impl MacAddress {
   }
 
   fn is_unicast(&self) -> bool {
-    (self.0[0] & 0b_0000_0001) == 0b_0000_0001
+    (self.0[0] & 0b_0000_0001) == 0b_0000_0000
   }
 }
 


### PR DESCRIPTION
To match MAC address specification (eg, as summarised at https://en.wikipedia.org/wiki/MAC_address#Address_details) and Figure 8.4 of the text, clear the LSB of the 1st octet when generating the MAC address, rather than setting it. Also update check for "is_unicast()" to match.

Equivalent fix (from 2020-08-13) in the ch8-mget example: https://github.com/rust-in-action/code/issues/7#issuecomment-672859672, which seems to have already been fixed when the first edition of the book was released (https://github.com/rust-in-action/code/commit/7d7955e9605ca156f6eb7cb5bc9f124c97927d25):

https://github.com/rust-in-action/code/blob/6ebd519f5a691a2f4c7d9cfbdb2d3e708e9d9681/ch8/ch8-mget/src/ethernet.rs#L23-L31

but apparently ch8/ch8-mac did not get fixed at the same time.