### PR TITLE
ch8-mget: Add iptables rules to workaround default DROP rules

### DIFF
--- a/ch8/ch8-mget/setup.sh
+++ b/ch8/ch8-mget/setup.sh
@@ -14,3 +14,7 @@ sudo ip -6 route add fe80::/64 dev tap-rust
 sudo ip -6 route add fdaa::/64 dev tap-rust
 sudo ip6tables -t nat -A POSTROUTING -s fdaa::/64 -j MASQUERADE
 sudo sysctl -w net.ipv6.conf.all.forwarding=1
+
+# Some distros have a default policy of DROP. This allows the traffic.
+sudo iptables -A FORWARD -i tap-rust -s 192.168.42.0/24 -j ACCEPT
+sudo iptables -A FORWARD -o tap-rust -d 192.168.42.0/24 -j ACCEPT


### PR DESCRIPTION
Hi!

The project of "ch8-mget" wasn't working for me. Basically, the process was hanging on the `SYN_SENT` TCP connection state. After some investigation, I've found 2 rules that the official documentation suggests adding for some distros: https://github.com/smoltcp-rs/smoltcp#hosted-usage-examples

I'm using Linux Mint 20.2 Cinnamon, 5.0.7, kernel 5.4.0-137-generic. After these rules were added, execution has worked as expected.

Many thanks!