### PR TITLE
Fix "illegal hardware instruction" in ch6-particles on MacOS

### DIFF
--- a/ch6/ch6-particles/src/main.rs
+++ b/ch6/ch6-particles/src/main.rs
@@ -18,6 +18,7 @@ struct ReportingAllocator;                       // <7>
                                                  //
                                                  // 
 /// Execute a closure without logging on allocations.
+/// Source: https://github.com/andrewhickman/logging-allocator/blob/master/src/lib.rs#L42-L57
 pub fn run_guarded<F>(f: F)
 where
     F: FnOnce(),

--- a/ch6/ch6-particles/src/main.rs
+++ b/ch6/ch6-particles/src/main.rs
@@ -7,12 +7,32 @@ use rand::prelude::*;                            // <3>
 use std::alloc::{GlobalAlloc, System, Layout};   // <4>
 
 use std::time::Instant;                          // <5>
+                                                 //
+use std::cell::Cell;
 
 
 #[global_allocator]                              // <6>
 static ALLOCATOR: ReportingAllocator = ReportingAllocator;
 
 struct ReportingAllocator;                       // <7>
+                                                 //
+                                                 // 
+/// Execute a closure without logging on allocations.
+pub fn run_guarded<F>(f: F)
+where
+    F: FnOnce(),
+{
+    thread_local! {
+        static GUARD: Cell<bool> = Cell::new(false);
+    }
+
+    GUARD.with(|guard| {
+        if !guard.replace(true) {
+            f();
+            guard.set(false)
+        }
+    })
+}
 
 unsafe impl GlobalAlloc for ReportingAllocator {
   unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
@@ -22,7 +42,7 @@ unsafe impl GlobalAlloc for ReportingAllocator {
     let time_taken = end - start;
     let bytes_requested = layout.size();
 
-    eprintln!("{}\t{}", bytes_requested, time_taken.as_nanos());
+    run_guarded(|| {eprintln!("{}\t{}", bytes_requested, time_taken.as_nanos())});
     ptr
   }
 


### PR DESCRIPTION
Fixes: https://github.com/rust-in-action/code/issues/93

Note that I blindly applied the workaround suggested by @pjstein , without really understanding it😅

Seems to fix the issue though (tested on MacOS 12.6.2  (Intel))